### PR TITLE
Update `php-amqplib` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": ">=7.0",
         "psr/log": "~1.0",
         "linio/util": "~2.0",
-        "videlalvaro/php-amqplib": "~2.6"
+        "php-amqplib/php-amqplib": "~2.6"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0"


### PR DESCRIPTION
Fix to the following warning:

> Package videlalvaro/php-amqplib is abandoned, you should avoid using it. Use php-amqplib/php-amqplib instead.
