### PR TITLE
[CC-1232] feat: add support to php 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ composer.phar
 composer.lock
 phpunit.xml
 cache.properties
-.php_cs.cache
+.php-cs-fixer.cache
 .phpunit.result.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -4,8 +4,9 @@ $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__ . '/src')
     ->in(__DIR__ . '/tests');
 
-return PhpCsFixer\Config::create()
-    ->setRules([
+$config = new PhpCsFixer\Config();
+
+return $config->setRules([
         '@Symfony' => true,
         '@PHP71Migration:risky' => true,
         '@PHPUnit60Migration:risky' => true,
@@ -13,15 +14,14 @@ return PhpCsFixer\Config::create()
         'array_syntax' => ['syntax' => 'short'],
         'blank_line_after_opening_tag' => true,
         'concat_space' => ['spacing' => 'one'],
-        'class_attributes_separation' => ['elements' => ['method']],
+        'class_attributes_separation' => ['elements' => ['method' => 'one']],
         'declare_strict_types' => true,
         'increment_style' => ['style' => 'post'],
-        'is_null' => ['use_yoda_style' => false],
         'list_syntax' => ['syntax' => 'short'],
-        'method_argument_space' => ['ensure_fully_multiline' => true],
+        'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
         'method_chaining_indentation' => true,
         'modernize_types_casting' => true,
-        'no_multiline_whitespace_before_semicolons' => true,
+        'multiline_whitespace_before_semicolons' => true,
         'no_superfluous_elseif' => true,
         'no_superfluous_phpdoc_tags' => false,
         'no_useless_else' => true,

--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,13 @@
   "type": "library",
   "license": "BSD-3-Clause",
   "require": {
-    "php": "^7.4",
+    "php": ">=7.4",
     "psr/log": "^1.0",
-    "linio/util": "^3.0",
-    "php-amqplib/php-amqplib": "^2.11"
+    "linio/util": "^3.0|^4.0",
+    "php-amqplib/php-amqplib": "^2.11|^3.2"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^2.16",
+    "friendsofphp/php-cs-fixer": "^3.4",
     "phpstan/phpstan": "^0.12",
     "phpunit/phpunit": "^8.5"
   },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,6 @@
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          executionOrder="depends,defects"
-         forceCoversAnnotation="true"
          beStrictAboutCoversAnnotation="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"

--- a/src/Queue/Adapter/RabbitAdapter.php
+++ b/src/Queue/Adapter/RabbitAdapter.php
@@ -7,7 +7,7 @@ namespace Linio\Component\Queue\Adapter;
 use Linio\Component\Queue\AdapterInterface;
 use Linio\Component\Queue\Job;
 use PhpAmqpLib\Channel\AMQPChannel;
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 
 class RabbitAdapter implements AdapterInterface
@@ -50,7 +50,7 @@ class RabbitAdapter implements AdapterInterface
     public function getChannel(): AMQPChannel
     {
         if (!$this->channel) {
-            $connection = new AMQPConnection($this->config['host'], $this->config['port'], $this->config['username'], $this->config['password'], $this->config['vhost']);
+            $connection = new AMQPStreamConnection($this->config['host'], $this->config['port'], $this->config['username'], $this->config['password'], $this->config['vhost']);
             $this->channel = $connection->channel();
         }
 

--- a/tests/Queue/QueueServiceTest.php
+++ b/tests/Queue/QueueServiceTest.php
@@ -53,7 +53,7 @@ class QueueServiceTest extends TestCase
         $loggerMock = $this->createMock('Psr\Log\LoggerInterface');
         $loggerMock->expects($this->once())
             ->method('error')
-            ->with($this->equalTo('[Queue] An error has occurred when adding job: Oops!'), $this->contains('Oops!'));
+            ->with($this->equalTo('[Queue] An error has occurred when adding job: Oops!'), $this->containsEqual('Oops!'));
 
         $adapterMock = $this->createMock('Linio\Component\Queue\AdapterInterface');
         $adapterMock->expects($this->once())
@@ -89,7 +89,7 @@ class QueueServiceTest extends TestCase
         $loggerMock = $this->createMock('Psr\Log\LoggerInterface');
         $loggerMock->expects($this->once())
             ->method('error')
-            ->with($this->stringStartsWith('[Queue] An error has occurred while performing'), $this->contains('Oops!'));
+            ->with($this->stringStartsWith('[Queue] An error has occurred while performing'), $this->containsEqual('Oops!'));
 
         $adapterMock = $this->createMock('Linio\Component\Queue\AdapterInterface');
         $adapterMock->expects($this->once())


### PR DESCRIPTION
**Goal**: Add support to PHP 8.

**Dependencies updated**: 

- [friendsofphp/php-cs-fixer](https://packagist.org/packages/friendsofphp/php-cs-fixer#v3.4.0) - must be >= 3.4 because of https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6145

**Deprecations fixed**:

- PhpAmqpLib\Connection\AMQPConnection was deprecated, using its parent PhpAmqpLib\Connection\AMQPStreamConnection instead, since there are no lost methods:
https://github.com/php-amqplib/php-amqplib/pull/897/files#diff-f335edbdd39701e7e2a7b44a647a54e0010f15508a06baca2a3db1836549f3eb
![AMQPConnection-deprecated](https://user-images.githubusercontent.com/73655563/185012690-d9952b56-ec92-474e-830b-746218e7790a.png)

- PhpUnit's test case Contains method was deprecated, using containsEqual() as suggested by the author:

![contains-deprecated](https://user-images.githubusercontent.com/73655563/185012841-7ce20ef3-9596-4ae4-801f-e9379484169a.png)

Relates to CC-1232